### PR TITLE
Removed print line on L196

### DIFF
--- a/Geo-IPinfo/lib/Geo/IPinfo.pm
+++ b/Geo-IPinfo/lib/Geo/IPinfo.pm
@@ -193,7 +193,7 @@ sub _lookup_info_from_source
 
   if ($response->is_success)
   {
-    print $response->decoded_content;
+   
     my $info = from_json($response->decoded_content);
 
     return ($info, '');


### PR DESCRIPTION
Removes the output to screen for each call to info.
This is a fix for issue #4 