### PR TITLE
v6.ipinfo.io doesn't work for IPv6, but ipinfo.io does

### DIFF
--- a/Geo-IPinfo/lib/Geo/IPinfo.pm
+++ b/Geo-IPinfo/lib/Geo/IPinfo.pm
@@ -35,7 +35,6 @@ my %valid_fields = (
     domains  => 1,
 );
 my $base_url          = 'https://ipinfo.io/';
-my $base_url_ipv6     = 'https://v6.ipinfo.io/';
 my $country_flag_url  = 'https://cdn.ipinfo.io/static/images/countries-flags/';
 my $cache_ttl    = 0;
 my $custom_cache = 0;
@@ -1062,7 +1061,7 @@ sub new {
     $token = defined $token ? $token : '';
 
     $self->{base_url}      = $base_url;
-    $self->{base_url_ipv6} = $base_url_ipv6;
+    $self->{base_url_ipv6} = $base_url;
     $self->{ua}            = LWP::UserAgent->new;
     $self->{ua}->ssl_opts( 'verify_hostname' => 0 );
     $self->{ua}->default_headers(
@@ -1273,7 +1272,7 @@ sub _lookup_info_from_source {
     } else {
         $url = $self->{base_url} . $key;
     }
-    
+
     my $response = $self->{ua}->get($url);
 
     if ( $response->is_success ) {

--- a/Geo-IPinfo/t/01-usage.t
+++ b/Geo-IPinfo/t/01-usage.t
@@ -5,7 +5,7 @@ use warnings;
 use Test::More;
 
 if ( $ENV{RELEASE_TESTING} ) {
-    plan tests => 7;
+    plan tests => 9;
 }
 else {
     plan( skip_all => "Basic usage tests not required for installation" );
@@ -35,3 +35,9 @@ is(
 );
 is( $ip->field( "192.168.0.1", "city" ),
     undef, "field() return 'undef' when getting fields of private IPs" );
+
+IPv6: {
+	my $h = $ip->info("2001:4860:4860::8888");
+	isa_ok $h, 'Geo::Details', "info() return a hash when querying a valid IPv6";
+	is $h->city, 'Mountain View', 'Google city is correct';
+}


### PR DESCRIPTION
It seems like you don't need separate hosts for the API for the different IP types.