### PR TITLE
Net::CIDR 0.22 fixes the non-compressed IPv6 issue; add repository metadata to Makefile.PL

### DIFF
--- a/Geo-IPinfo/Makefile.PL
+++ b/Geo-IPinfo/Makefile.PL
@@ -21,7 +21,7 @@ WriteMakefile(
         'LWP::UserAgent'          => '0',
         'JSON'                    => '0',
         'Cache::LRU'              => '0',
-        'Net::CIDR'               => '0',      
+        'Net::CIDR'               => '0.22',
         'Net::CIDR::Set'          => '0',
     },
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },

--- a/Geo-IPinfo/Makefile.PL
+++ b/Geo-IPinfo/Makefile.PL
@@ -26,6 +26,22 @@ WriteMakefile(
     },
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean => { FILES => 'Geo-IPinfo-*' },
+
+    'META_MERGE' => {
+        'meta-spec' => { version => 2 },
+        keywords    => ['geo', 'network'],
+        resources => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/ipinfo/perl',
+                web  => 'https://github.com/ipinfo/perl',
+                },
+            bugtracker => {
+                web    => "https://github.com/ipinfo/perl/issues",
+                },
+            homepage => 'https://ipinfo.io',
+            },
+        },
 );
 
 package MY;


### PR DESCRIPTION
This fixes #34, and adds the stuff MetaCPAN needs to make the right links for this module.