### PR TITLE
Fix failing resproxy tests caused by data change

### DIFF
--- a/Geo-IPinfo/Makefile.PL
+++ b/Geo-IPinfo/Makefile.PL
@@ -16,6 +16,8 @@ WriteMakefile(
     },
     BUILD_REQUIRES => {
         'Test::More' => '0',
+        'Test::Mock::LWP::Dispatch' => '0',
+        'HTTP::Response' => '0',
     },
     PREREQ_PM => {
         'LWP::UserAgent'          => '0',

--- a/Geo-IPinfo/t/05-usage-resproxy.t
+++ b/Geo-IPinfo/t/05-usage-resproxy.t
@@ -12,19 +12,42 @@ else {
 }
 
 use_ok('Geo::IPinfo');
+use Test::Mock::LWP::Dispatch;
+use HTTP::Response;
 
 my $ip;
 
-$ip = Geo::IPinfo->new( $ENV{IPINFO_TOKEN} );
+# Set up mock responses
+$mock_ua->map(
+    qr{https://ipinfo\.io/resproxy/175\.107\.211\.204},
+    sub {
+        my $response = HTTP::Response->new(200);
+        $response->header('Content-Type' => 'application/json');
+        $response->content('{"ip":"175.107.211.204","last_seen":"2025-01-20","percent_days_seen":0.85,"service":"example_service"}');
+        return $response;
+    }
+);
+
+$mock_ua->map(
+    qr{https://ipinfo\.io/resproxy/8\.8\.8\.8},
+    sub {
+        my $response = HTTP::Response->new(200);
+        $response->header('Content-Type' => 'application/json');
+        $response->content('{}');
+        return $response;
+    }
+);
+
+$ip = Geo::IPinfo->new("test_token");
 isa_ok( $ip, "Geo::IPinfo", '$ip' );
 
 # Test resproxy with known residential proxy IP
 my $resproxy = $ip->resproxy("175.107.211.204");
 ok( $resproxy, "resproxy() returns data for known residential proxy IP" );
 is( $resproxy->{ip}, "175.107.211.204", "IP field is correct" );
-ok( defined $resproxy->{last_seen}, "last_seen field is defined" );
-ok( defined $resproxy->{percent_days_seen}, "percent_days_seen field is defined" );
-ok( defined $resproxy->{service}, "service field is defined" );
+is( $resproxy->{last_seen}, "2025-01-20", "last_seen field is correct" );
+is( $resproxy->{percent_days_seen}, 0.85, "percent_days_seen field is correct" );
+is( $resproxy->{service}, "example_service", "service field is correct" );
 
 # Test resproxy with IP that returns empty response
 my $empty_resproxy = $ip->resproxy("8.8.8.8");


### PR DESCRIPTION
Resproxy tests were failing because the IP that I used to test the API is not in the dataset anymore, so an empty response is returned. This PR fixes the issue by mocking the expected response.