### PR TITLE
Update Bulgaria currency from BGN to EUR

### DIFF
--- a/Geo-IPinfo/lib/Geo/IPinfo.pm
+++ b/Geo-IPinfo/lib/Geo/IPinfo.pm
@@ -570,7 +570,7 @@ my %default_countries_currencies = (
     'BD' => { 'code' => 'BDT', 'symbol' => '৳' },
     'BE' => { 'code' => 'EUR', 'symbol' => '€' },
     'BF' => { 'code' => 'XOF', 'symbol' => 'CFA' },
-    'BG' => { 'code' => 'BGN', 'symbol' => 'лв' },
+    'BG' => { 'code' => 'EUR', 'symbol' => '€' },
     'BH' => { 'code' => 'BHD', 'symbol' => '.د.ب' },
     'BI' => { 'code' => 'BIF', 'symbol' => 'FBu' },
     'BJ' => { 'code' => 'XOF', 'symbol' => 'CFA' },

--- a/Geo-IPinfo/lib/Geo/IPinfoLite.pm
+++ b/Geo-IPinfo/lib/Geo/IPinfoLite.pm
@@ -562,7 +562,7 @@ my %default_countries_currencies = (
     'BD' => { 'code' => 'BDT', 'symbol' => '৳' },
     'BE' => { 'code' => 'EUR', 'symbol' => '€' },
     'BF' => { 'code' => 'XOF', 'symbol' => 'CFA' },
-    'BG' => { 'code' => 'BGN', 'symbol' => 'лв' },
+    'BG' => { 'code' => 'EUR', 'symbol' => '€' },
     'BH' => { 'code' => 'BHD', 'symbol' => '.د.ب' },
     'BI' => { 'code' => 'BIF', 'symbol' => 'FBu' },
     'BJ' => { 'code' => 'XOF', 'symbol' => 'CFA' },


### PR DESCRIPTION
Bulgaria adopted the Euro starting 1/1/26, this PR changes the country currency code and symbol to reflect that.